### PR TITLE
Add encrypted session cookie for Socrata OAuth and API key auth

### DIFF
--- a/.env.databricks.example
+++ b/.env.databricks.example
@@ -25,8 +25,3 @@ LLM_MODEL=your-model-name
 SOCRATA_SECRET_TOKEN=your-socrata-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://your-databricks-app-url/api/auth/socrata/callback
 FRONTEND_URL=https://your-databricks-app-url
-
-# Fernet key encrypting the OAuth session cookie. Generate once with:
-#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-# Required when SOCRATA_SECRET_TOKEN is set. Rotating invalidates all sessions.
-SESSION_ENCRYPTION_KEY=

--- a/.env.databricks.example
+++ b/.env.databricks.example
@@ -25,3 +25,8 @@ LLM_MODEL=your-model-name
 SOCRATA_SECRET_TOKEN=your-socrata-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://your-databricks-app-url/api/auth/socrata/callback
 FRONTEND_URL=https://your-databricks-app-url
+
+# Fernet key encrypting the OAuth session cookie. Generate once with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Required when SOCRATA_SECRET_TOKEN is set. Rotating invalidates all sessions.
+SESSION_ENCRYPTION_KEY=

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # For backend configuration, see backend/.env.example
 
 # Backend API URL
-# - For local development: http://localhost:8000
-# - For Databricks deployment: leave empty (uses relative URLs)
-VITE_API_BASE_URL=http://localhost:8000
+# - Leave empty for both local dev (Vite proxies /api/* to backend on :8000)
+#   and Databricks (backend serves the frontend at the same origin).
+# - Only set this if you're running the frontend against a non-proxied backend.
+VITE_API_BASE_URL=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,10 @@ cd ..
 
    # Server Configuration
    PORT=8000
+
+   # Session cookie lifetime in seconds. Default 86400 (1 day). Applies to both
+   # the browser cookie Max-Age and the server-side Fernet TTL check.
+   # SESSION_COOKIE_MAX_AGE_SECONDS=86400
    ```
 
 ### Running the App

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -50,11 +50,6 @@ cd ..
    # Must match the Callback Prefix domain registered on data.wa.gov
    SOCRATA_OAUTH_REDIRECT_URI=https://your-ngrok-url.ngrok-free.app/api/auth/socrata/callback
 
-   # Fernet key for encrypting the session cookie. Generate once with:
-   #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-   # Required for "Sign in with data.wa.gov" and API key auth.
-   SESSION_ENCRYPTION_KEY=your-fernet-key
-
    # Default LLM endpoint (optional — can also be set via frontend UI)
    # Works with any OpenAI-compatible API (OpenAI, Azure, HuggingFace, etc.)
    LLM_ENDPOINT=https://api.openai.com/v1
@@ -127,7 +122,6 @@ SOCRATA_APP_TOKEN=your-app-token
 SOCRATA_SECRET_TOKEN=your-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://abc123.ngrok-free.app/api/auth/socrata/callback
 FRONTEND_URL=http://localhost:5173
-SESSION_ENCRYPTION_KEY=your-fernet-key
 ```
 
 - `SOCRATA_APP_TOKEN`: The App Token from step 1 (also used as the OAuth `client_id`)
@@ -232,11 +226,6 @@ LLM_MODEL=your-model-name
 SOCRATA_SECRET_TOKEN=your-socrata-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://your-databricks-app-url/api/auth/socrata/callback
 FRONTEND_URL=https://your-databricks-app-url
-
-# Fernet key for encrypting the session cookie. Generate once with:
-#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-# Required for Socrata OAuth and API key auth. Rotating invalidates all sessions.
-SESSION_ENCRYPTION_KEY=
 ```
 
 > **Important:** `.env.databricks` contains secrets and is gitignored. Only `.env.databricks.example` (with placeholder values) is committed. Do not commit `.env.databricks` to the repository.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -128,7 +128,6 @@ FRONTEND_URL=http://localhost:5173
 - `SOCRATA_SECRET_TOKEN`: The Secret Token from step 1
 - `SOCRATA_OAUTH_REDIRECT_URI`: Must match the Callback Prefix domain registered on data.wa.gov
 - `FRONTEND_URL`: Where the browser redirects after OAuth (your frontend dev server)
-- `SESSION_ENCRYPTION_KEY`: Fernet key for encrypting the session cookie — generate one with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
 
 #### 4. Test the Flow
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -50,6 +50,11 @@ cd ..
    # Must match the Callback Prefix domain registered on data.wa.gov
    SOCRATA_OAUTH_REDIRECT_URI=https://your-ngrok-url.ngrok-free.app/api/auth/socrata/callback
 
+   # Fernet key for encrypting the session cookie. Generate once with:
+   #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   # Required for "Sign in with data.wa.gov" and API key auth.
+   SESSION_ENCRYPTION_KEY=your-fernet-key
+
    # Default LLM endpoint (optional — can also be set via frontend UI)
    # Works with any OpenAI-compatible API (OpenAI, Azure, HuggingFace, etc.)
    LLM_ENDPOINT=https://api.openai.com/v1
@@ -78,6 +83,8 @@ npm run dev
 ### Socrata OAuth Setup (Sign in with data.wa.gov)
 
 OAuth login allows users to authenticate with data.wa.gov instead of manually entering API credentials.
+
+> **Alternative — API Key (Basic Auth):** If you don't want to use OAuth, you can also authenticate by entering your Socrata API key directly in the app (Import page → "Enter API Key" tab). The key is stored in the same encrypted session cookie as OAuth tokens, so no sensitive data touches localStorage.
 
 #### 1. Register an OAuth App on data.wa.gov
 
@@ -120,12 +127,14 @@ SOCRATA_APP_TOKEN=your-app-token
 SOCRATA_SECRET_TOKEN=your-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://abc123.ngrok-free.app/api/auth/socrata/callback
 FRONTEND_URL=http://localhost:5173
+SESSION_ENCRYPTION_KEY=your-fernet-key
 ```
 
 - `SOCRATA_APP_TOKEN`: The App Token from step 1 (also used as the OAuth `client_id`)
 - `SOCRATA_SECRET_TOKEN`: The Secret Token from step 1
 - `SOCRATA_OAUTH_REDIRECT_URI`: Must match the Callback Prefix domain registered on data.wa.gov
 - `FRONTEND_URL`: Where the browser redirects after OAuth (your frontend dev server)
+- `SESSION_ENCRYPTION_KEY`: Fernet key for encrypting the session cookie — generate one with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
 
 #### 4. Test the Flow
 
@@ -223,6 +232,11 @@ LLM_MODEL=your-model-name
 SOCRATA_SECRET_TOKEN=your-socrata-secret-token
 SOCRATA_OAUTH_REDIRECT_URI=https://your-databricks-app-url/api/auth/socrata/callback
 FRONTEND_URL=https://your-databricks-app-url
+
+# Fernet key for encrypting the session cookie. Generate once with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Required for Socrata OAuth and API key auth. Rotating invalidates all sessions.
+SESSION_ENCRYPTION_KEY=
 ```
 
 > **Important:** `.env.databricks` contains secrets and is gitignored. Only `.env.databricks.example` (with placeholder values) is committed. Do not commit `.env.databricks` to the repository.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,6 +17,10 @@ SOCRATA_OAUTH_REDIRECT_URI=http://localhost:8000/api/auth/socrata/callback
 # SESSION_COOKIE_SECURE=true
 # SESSION_COOKIE_SAMESITE=lax
 
+# Session cookie lifetime in seconds. Default 86400 (1 day). Applies to both
+# the browser cookie Max-Age and the server-side Fernet TTL check.
+# SESSION_COOKIE_MAX_AGE_SECONDS=86400
+
 # Default LLM endpoint (optional - can also be set via UI)
 # Works with any OpenAI-compatible API (OpenAI, Azure, HuggingFace, etc.)
 # Recommended models: gpt-5-mini, gpt-5-nano, Qwen3-4B-Instruct-2507, Qwen/Qwen3-8B,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,17 @@ SOCRATA_SECRET_TOKEN=
 # Where data.wa.gov redirects after OAuth login (must match your registered app)
 SOCRATA_OAUTH_REDIRECT_URI=http://localhost:8000/api/auth/socrata/callback
 
+# Fernet key used to encrypt the OAuth session cookie. Generate once with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Required for the "Sign in with data.wa.gov" flow. Rotating the key invalidates
+# all existing sessions.
+SESSION_ENCRYPTION_KEY=
+
+# Cookie flags. Default Secure=true (HTTPS only) + SameSite=Lax (recommended).
+# For local dev without HTTPS, set SESSION_COOKIE_SECURE=false (Vite proxy required).
+# SESSION_COOKIE_SECURE=true
+# SESSION_COOKIE_SAMESITE=lax
+
 # Default LLM endpoint (optional - can also be set via UI)
 # Works with any OpenAI-compatible API (OpenAI, Azure, HuggingFace, etc.)
 # Recommended models: gpt-5-mini, gpt-5-nano, Qwen3-4B-Instruct-2507, Qwen/Qwen3-8B,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,12 +12,6 @@ SOCRATA_SECRET_TOKEN=
 # Where data.wa.gov redirects after OAuth login (must match your registered app)
 SOCRATA_OAUTH_REDIRECT_URI=http://localhost:8000/api/auth/socrata/callback
 
-# Fernet key used to encrypt the OAuth session cookie. Generate once with:
-#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-# Required for the "Sign in with data.wa.gov" flow. Rotating the key invalidates
-# all existing sessions.
-SESSION_ENCRYPTION_KEY=
-
 # Cookie flags. Default Secure=true (HTTPS only) + SameSite=Lax (recommended).
 # For local dev without HTTPS, set SESSION_COOKIE_SECURE=false (Vite proxy required).
 # SESSION_COOKIE_SECURE=true

--- a/backend/main.py
+++ b/backend/main.py
@@ -110,13 +110,16 @@ async def add_security_headers(
 ) -> Response:
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["X-XSS-Protection"] = "1; mode=block"
+    # SAMEORIGIN (not DENY): Databricks Apps serves frontend + backend at the
+    # same origin and documents an optional iframe embedding path. CSP
+    # frame-ancestors 'self' is the modern equivalent.
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["Strict-Transport-Security"] = (
         "max-age=31536000; includeSubDomains"
     )
     response.headers["Content-Security-Policy"] = (
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+        "default-src 'self'; script-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; frame-ancestors 'self'"
     )
     return response
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -68,7 +68,16 @@ _SESSION_ENCRYPTION_KEY = Fernet.generate_key().decode()
 _fernet = Fernet(_SESSION_ENCRYPTION_KEY.encode())
 
 SESSION_COOKIE_NAME = "socrata_session"
-SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7  # 7 days
+try:
+    SESSION_COOKIE_MAX_AGE = int(
+        os.getenv("SESSION_COOKIE_MAX_AGE_SECONDS", str(60 * 60 * 24))
+    )
+except ValueError as exc:
+    raise RuntimeError(
+        "SESSION_COOKIE_MAX_AGE_SECONDS must be a positive integer"
+    ) from exc
+if SESSION_COOKIE_MAX_AGE <= 0:
+    raise RuntimeError("SESSION_COOKIE_MAX_AGE_SECONDS must be a positive integer")
 
 # Cookies need SameSite=None;Secure for cross-site (e.g. Databricks app URL)
 # and Lax/Secure for same-origin. Default Lax; Databricks deployment is HTTPS.
@@ -94,7 +103,11 @@ app = FastAPI(
 # are same-origin (Databricks Apps), so no CORS preflight fires. In dev, the
 # Vite proxy forwards /api/* same-origin, so this mainly guards against direct
 # cross-origin calls. FRONTEND_URL is the canonical allowed origin.
-_cors_origins = [FRONTEND_URL] if FRONTEND_URL else []
+_cors_origins = (
+    [FRONTEND_URL]
+    if FRONTEND_URL
+    else ["http://localhost:5173", "http://localhost:8000"]
+)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
@@ -161,7 +174,7 @@ def _read_session(request: Request) -> dict[str, str] | None:
     if not raw:
         return None
     try:
-        decrypted = _fernet.decrypt(raw.encode()).decode()
+        decrypted = _fernet.decrypt(raw.encode(), ttl=SESSION_COOKIE_MAX_AGE).decode()
         data = json.loads(decrypted)
         if not isinstance(data, dict) or "kind" not in data:
             return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
@@ -24,6 +24,7 @@ from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from openai import APIStatusError, AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
+from starlette.middleware.base import RequestResponseEndpoint
 
 from .models import (
     ChatRequest,
@@ -56,16 +57,15 @@ FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173")
 LLM_ENDPOINT = os.getenv("LLM_ENDPOINT", "")
 LLM_API_KEY = os.getenv("LLM_API_KEY", "")
 LLM_MODEL = os.getenv("LLM_MODEL", "")
-# Secret for signing OAuth state tokens (used to prevent CSRF)
-_OAUTH_STATE_SECRET = (
-    os.getenv("OAUTH_STATE_SECRET") or SOCRATA_SECRET_TOKEN or secrets.token_hex(32)
-)
+# Secret for signing OAuth state tokens (used to prevent CSRF).
+# Generated fresh on every server start — if the server restarts, users simply
+# re-initiate the OAuth flow.  This is stronger than deriving from SOCRATA_SECRET_TOKEN.
+_OAUTH_STATE_SECRET = secrets.token_hex(32)
 
-# Fernet key for encrypting the OAuth session cookie. Generate with
-# `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
-# and set in the environment. Cookies are invalidated on key rotation.
-_SESSION_ENCRYPTION_KEY = os.getenv("SESSION_ENCRYPTION_KEY", "")
-_fernet: Fernet | None = Fernet(_SESSION_ENCRYPTION_KEY.encode()) if _SESSION_ENCRYPTION_KEY else None
+# Fernet key for encrypting the OAuth session cookie. Generated fresh on every
+# server start — sessions are invalidated on restart.
+_SESSION_ENCRYPTION_KEY = Fernet.generate_key().decode()
+_fernet = Fernet(_SESSION_ENCRYPTION_KEY.encode())
 
 SESSION_COOKIE_NAME = "socrata_session"
 SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7  # 7 days
@@ -73,7 +73,12 @@ SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7  # 7 days
 # Cookies need SameSite=None;Secure for cross-site (e.g. Databricks app URL)
 # and Lax/Secure for same-origin. Default Lax; Databricks deployment is HTTPS.
 _COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "true").lower() != "false"
-_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "lax")
+_samesite_raw = os.getenv("SESSION_COOKIE_SAMESITE", "lax").lower()
+_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = (
+    "strict"
+    if _samesite_raw == "strict"
+    else "none" if _samesite_raw == "none" else "lax"
+)
 
 # For Databricks Apps, the port is typically provided via environment variable
 PORT = int(os.getenv("PORT", "8000"))
@@ -94,9 +99,26 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Requested-With"],
 )
+
+
+@app.middleware("http")
+async def add_security_headers(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Strict-Transport-Security"] = (
+        "max-age=31536000; includeSubDomains"
+    )
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    )
+    return response
 
 
 # Health check endpoint
@@ -118,11 +140,6 @@ def _set_session_payload(response: Response, payload: dict[str, str]) -> None:
         {"kind": "oauth", "token": "..."}
         {"kind": "api_key", "id": "...", "secret": "..."}
     """
-    if not _fernet:
-        raise HTTPException(
-            status_code=500,
-            detail="SESSION_ENCRYPTION_KEY not configured on the server.",
-        )
     encrypted = _fernet.encrypt(json.dumps(payload).encode()).decode()
     response.set_cookie(
         SESSION_COOKIE_NAME,
@@ -137,8 +154,6 @@ def _set_session_payload(response: Response, payload: dict[str, str]) -> None:
 
 def _read_session(request: Request) -> dict[str, str] | None:
     """Decrypt the session cookie. Returns the payload dict or None."""
-    if not _fernet:
-        return None
     raw = request.cookies.get(SESSION_COOKIE_NAME)
     if not raw:
         return None
@@ -202,7 +217,7 @@ async def socrata_oauth_callback(
     code: str | None = None,
     error: str | None = None,
     state: str | None = None,
-):
+) -> RedirectResponse:
     """OAuth callback — exchanges authorization code for access token, redirects to frontend."""
     base = FRONTEND_URL.rstrip("/") if FRONTEND_URL else ""
 
@@ -454,7 +469,7 @@ async def _soda_get(
             resp.text[:300],
         )
         return []
-    return resp.json()
+    return cast(list[dict[str, Any]], resp.json())
 
 
 async def _compute_numeric_stats(
@@ -877,7 +892,9 @@ async def socrata_export(
             if request.category is not None:
                 parts.append("category")
             if request.tags is not None:
-                parts.append(f"{len(request.tags)} tag{'s' if len(request.tags) != 1 else ''}")
+                parts.append(
+                    f"{len(request.tags)} tag{'s' if len(request.tags) != 1 else ''}"
+                )
             if updated_col_count > 0:
                 parts.append(
                     f"{updated_col_count} column description{'s' if updated_col_count != 1 else ''}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,8 +16,9 @@ from urllib.parse import urlencode
 logger = logging.getLogger(__name__)
 
 import httpx
+from cryptography.fernet import Fernet, InvalidToken
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -28,6 +29,7 @@ from .models import (
     ChatRequest,
     ColumnStats,
     HealthResponse,
+    SocrataApiKeyRequest,
     SocrataCategoriesResponse,
     SocrataColumnMetadata,
     SocrataExportRequest,
@@ -35,8 +37,8 @@ from .models import (
     SocrataImportRequest,
     SocrataImportResponse,
     SocrataOAuthLoginResponse,
-    SocrataOAuthUserInfoRequest,
     SocrataOAuthUserInfo,
+    SocrataSessionResponse,
 )
 
 # Load environment variables from .env file (local dev) and .env.databricks (Databricks deployment)
@@ -59,6 +61,20 @@ _OAUTH_STATE_SECRET = (
     os.getenv("OAUTH_STATE_SECRET") or SOCRATA_SECRET_TOKEN or secrets.token_hex(32)
 )
 
+# Fernet key for encrypting the OAuth session cookie. Generate with
+# `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+# and set in the environment. Cookies are invalidated on key rotation.
+_SESSION_ENCRYPTION_KEY = os.getenv("SESSION_ENCRYPTION_KEY", "")
+_fernet: Fernet | None = Fernet(_SESSION_ENCRYPTION_KEY.encode()) if _SESSION_ENCRYPTION_KEY else None
+
+SESSION_COOKIE_NAME = "socrata_session"
+SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7  # 7 days
+
+# Cookies need SameSite=None;Secure for cross-site (e.g. Databricks app URL)
+# and Lax/Secure for same-origin. Default Lax; Databricks deployment is HTTPS.
+_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "true").lower() != "false"
+_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "lax")
+
 # For Databricks Apps, the port is typically provided via environment variable
 PORT = int(os.getenv("PORT", "8000"))
 
@@ -68,10 +84,15 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORS middleware - more permissive for Databricks Apps
+# CORS: cookie-based sessions require a concrete allowed origin (wildcard +
+# credentials is rejected by browsers). In production the backend and frontend
+# are same-origin (Databricks Apps), so no CORS preflight fires. In dev, the
+# Vite proxy forwards /api/* same-origin, so this mainly guards against direct
+# cross-origin calls. FRONTEND_URL is the canonical allowed origin.
+_cors_origins = [FRONTEND_URL] if FRONTEND_URL else []
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Databricks Apps handles auth
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -88,6 +109,51 @@ async def health_check() -> HealthResponse:
 
 
 # Socrata OAuth endpoints
+
+
+def _set_session_payload(response: Response, payload: dict[str, str]) -> None:
+    """Encrypt an auth payload into the session cookie.
+
+    Payload shapes:
+        {"kind": "oauth", "token": "..."}
+        {"kind": "api_key", "id": "...", "secret": "..."}
+    """
+    if not _fernet:
+        raise HTTPException(
+            status_code=500,
+            detail="SESSION_ENCRYPTION_KEY not configured on the server.",
+        )
+    encrypted = _fernet.encrypt(json.dumps(payload).encode()).decode()
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        encrypted,
+        max_age=SESSION_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=_COOKIE_SECURE,
+        samesite=_COOKIE_SAMESITE,
+        path="/",
+    )
+
+
+def _read_session(request: Request) -> dict[str, str] | None:
+    """Decrypt the session cookie. Returns the payload dict or None."""
+    if not _fernet:
+        return None
+    raw = request.cookies.get(SESSION_COOKIE_NAME)
+    if not raw:
+        return None
+    try:
+        decrypted = _fernet.decrypt(raw.encode()).decode()
+        data = json.loads(decrypted)
+        if not isinstance(data, dict) or "kind" not in data:
+            return None
+        return data
+    except (InvalidToken, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE_NAME, path="/")
 
 
 def _build_oauth_authorize_url(is_retry: bool = False) -> str:
@@ -216,45 +282,106 @@ async def socrata_oauth_callback(
             if not access_token:
                 return RedirectResponse(url=f"{base}/#oauth_error=no_access_token")
 
-            return RedirectResponse(url=f"{base}/#oauth_token={access_token}")
+            # Success: set encrypted HttpOnly cookie, redirect to frontend home.
+            # The frontend calls /api/auth/socrata/session on load to discover the session.
+            redirect = RedirectResponse(url=base or "/")
+            _set_session_payload(redirect, {"kind": "oauth", "token": access_token})
+            return redirect
 
     except Exception as e:
         logger.exception("OAuth callback error: %s", str(e))
         return RedirectResponse(url=f"{base}/#oauth_error=server_error")
 
 
-@app.post("/api/auth/socrata/userinfo", response_model=SocrataOAuthUserInfo)
-async def socrata_oauth_userinfo(
-    body: SocrataOAuthUserInfoRequest,
-) -> SocrataOAuthUserInfo:
-    """Fetch the current authenticated user's info from data.wa.gov."""
-    token = body.oauthToken
+@app.get("/api/auth/socrata/session", response_model=SocrataSessionResponse)
+async def socrata_session(request: Request) -> SocrataSessionResponse:
+    """Return the state of the current auth session (OAuth or API key)."""
+    session = _read_session(request)
+    if not session:
+        return SocrataSessionResponse(kind=None)
 
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(
-                "https://data.wa.gov/api/users/current.json",
-                headers={"Authorization": f"OAuth {token}"},
-            )
+    kind = session.get("kind")
 
-            if resp.status_code != 200:
-                raise HTTPException(
-                    status_code=401, detail="Invalid or expired OAuth token"
+    if kind == "oauth":
+        token = session.get("token") or ""
+        if not token:
+            return SocrataSessionResponse(kind=None)
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(
+                    "https://data.wa.gov/api/users/current.json",
+                    headers={"Authorization": f"OAuth {token}"},
                 )
+                if resp.status_code != 200:
+                    return SocrataSessionResponse(kind=None)
+                user_data = resp.json()
+                return SocrataSessionResponse(
+                    kind="oauth",
+                    user=SocrataOAuthUserInfo(
+                        id=user_data.get("id", ""),
+                        displayName=user_data.get("displayName", ""),
+                        email=user_data.get("email"),
+                    ),
+                )
+        except Exception as e:
+            logger.exception("Session OAuth lookup failed: %s", str(e))
+            return SocrataSessionResponse(kind=None)
 
-            user_data = resp.json()
-            return SocrataOAuthUserInfo(
-                id=user_data.get("id", ""),
-                displayName=user_data.get("displayName", ""),
-                email=user_data.get("email"),
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception("OAuth userinfo error: %s", str(e))
+    if kind == "api_key":
+        return SocrataSessionResponse(kind="api_key", apiKeyId=session.get("id", ""))
+
+    return SocrataSessionResponse(kind=None)
+
+
+@app.put("/api/auth/socrata/api-key", status_code=204)
+async def socrata_api_key_save(
+    body: SocrataApiKeyRequest, response: Response
+) -> Response:
+    """Store a Socrata API key (id + secret) in the encrypted session cookie.
+
+    Replaces any existing OAuth or API key session.
+    """
+    key_id = body.apiKeyId.strip()
+    key_secret = body.apiKeySecret.strip()
+    if not key_id or not key_secret:
         raise HTTPException(
-            status_code=500, detail=f"Failed to fetch user info: {str(e)}"
+            status_code=400, detail="Both apiKeyId and apiKeySecret are required."
         )
+    _set_session_payload(
+        response, {"kind": "api_key", "id": key_id, "secret": key_secret}
+    )
+    response.status_code = 204
+    return response
+
+
+@app.post("/api/auth/socrata/logout", status_code=204)
+async def socrata_logout(request: Request, response: Response) -> Response:
+    """Clear the session cookie. For OAuth sessions, also revoke upstream."""
+    session = _read_session(request)
+    if (
+        session
+        and session.get("kind") == "oauth"
+        and SOCRATA_APP_TOKEN
+        and SOCRATA_SECRET_TOKEN
+    ):
+        token = session.get("token")
+        if token:
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    await client.post(
+                        "https://data.wa.gov/oauth/revoke_token",
+                        data={
+                            "access_token": token,
+                            "client_id": SOCRATA_APP_TOKEN,
+                            "client_secret": SOCRATA_SECRET_TOKEN,
+                        },
+                    )
+            except Exception:
+                # Revoke is best-effort — the cookie is still invalidated below.
+                logger.exception("Upstream token revoke failed")
+    _clear_session_cookie(response)
+    response.status_code = 204
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -275,12 +402,12 @@ _categories_cache: dict[str, Any] = {"value": None, "fetched_at": 0.0}
 _CATEGORIES_TTL_SECONDS = 24 * 60 * 60
 
 
-def build_socrata_auth(
-    request: SocrataImportRequest | SocrataExportRequest,
-) -> dict[str, str]:
-    """Build auth headers from import/export request.
+def build_socrata_auth(session: dict[str, str] | None) -> dict[str, str]:
+    """Build auth headers from an encrypted session payload.
 
-    Priority: OAuth token > API Key (Basic Auth) > app token only.
+    `session` is the decrypted cookie payload (OAuth or API key) or None.
+    Falls back to X-App-Token-only auth (read-only, public datasets) when no
+    session is present.
     """
     if not SOCRATA_APP_TOKEN:
         raise HTTPException(
@@ -290,13 +417,15 @@ def build_socrata_auth(
 
     headers: dict[str, str] = {"X-App-Token": SOCRATA_APP_TOKEN}
 
-    if request.oauthToken:
-        headers["Authorization"] = f"OAuth {request.oauthToken}"
-    elif request.apiKeyId and request.apiKeySecret:
-        credentials = base64.b64encode(
-            f"{request.apiKeyId}:{request.apiKeySecret}".encode()
-        ).decode()
-        headers["Authorization"] = f"Basic {credentials}"
+    if session:
+        kind = session.get("kind")
+        if kind == "oauth" and session.get("token"):
+            headers["Authorization"] = f"OAuth {session['token']}"
+        elif kind == "api_key" and session.get("id") and session.get("secret"):
+            credentials = base64.b64encode(
+                f"{session['id']}:{session['secret']}".encode()
+            ).decode()
+            headers["Authorization"] = f"Basic {credentials}"
 
     return headers
 
@@ -530,12 +659,15 @@ async def _compute_column_stats(
 
 
 @app.post("/api/socrata/import", response_model=SocrataImportResponse)
-async def socrata_import(request: SocrataImportRequest) -> SocrataImportResponse:
+async def socrata_import(
+    request: SocrataImportRequest, http_request: Request
+) -> SocrataImportResponse:
     if not request.datasetId or not request.datasetId.strip():
         raise HTTPException(status_code=400, detail="Dataset ID is required")
 
     dataset_id = request.datasetId.strip()
-    headers = build_socrata_auth(request)
+    session = _read_session(http_request)
+    headers = build_socrata_auth(session)
 
     metadata_url = f"https://data.wa.gov/api/views/{dataset_id}.json"
     soda_base = f"https://data.wa.gov/resource/{dataset_id}.json"
@@ -641,21 +773,24 @@ async def socrata_import(request: SocrataImportRequest) -> SocrataImportResponse
 
 # Socrata export endpoint — pushes updated metadata back to data.wa.gov
 @app.post("/api/socrata/export", response_model=SocrataExportResponse)
-async def socrata_export(request: SocrataExportRequest) -> SocrataExportResponse:
+async def socrata_export(
+    request: SocrataExportRequest, http_request: Request
+) -> SocrataExportResponse:
     if not request.datasetId or not request.datasetId.strip():
         raise HTTPException(status_code=400, detail="Dataset ID is required")
 
     dataset_id = request.datasetId.strip()
+    session = _read_session(http_request)
 
-    # Build auth — write operations require authentication (OAuth or API Key)
-    if not request.oauthToken and not (request.apiKeyId and request.apiKeySecret):
+    # Write operations require authentication — OAuth or API key
+    if not session or session.get("kind") not in ("oauth", "api_key"):
         raise HTTPException(
-            status_code=400,
+            status_code=401,
             detail="Authentication required to update metadata on data.wa.gov. "
-            "Please sign in with OAuth or provide API Key credentials.",
+            "Please sign in with OAuth or save an API key.",
         )
 
-    headers = build_socrata_auth(request)
+    headers = build_socrata_auth(session)
     headers["Content-Type"] = "application/json"
 
     metadata_url = f"https://data.wa.gov/api/views/{dataset_id}.json"

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Any
+from typing import Any, Literal
 
 
 # ============================================================================
@@ -35,12 +35,12 @@ class HealthResponse(BaseModel):
 
 
 class SocrataImportRequest(BaseModel):
-    """Request to import a dataset from data.wa.gov by dataset ID."""
+    """Request to import a dataset from data.wa.gov by dataset ID.
+
+    Auth (OAuth token or API key) is read from the encrypted session cookie.
+    """
 
     datasetId: str
-    oauthToken: str | None = None
-    apiKeyId: str | None = None
-    apiKeySecret: str | None = None
 
 
 class SocrataColumnMetadata(BaseModel):
@@ -89,12 +89,12 @@ class SocrataColumnUpdate(BaseModel):
 
 
 class SocrataExportRequest(BaseModel):
-    """Request to push updated metadata back to data.wa.gov."""
+    """Request to push updated metadata back to data.wa.gov.
+
+    Auth (OAuth token or API key) is read from the encrypted session cookie.
+    """
 
     datasetId: str
-    oauthToken: str | None = None
-    apiKeyId: str | None = None
-    apiKeySecret: str | None = None
     datasetTitle: str | None = None
     datasetDescription: str | None = None
     rowLabel: str | None = None
@@ -133,15 +133,33 @@ class SocrataOAuthLoginResponse(BaseModel):
     authUrl: str
 
 
-class SocrataOAuthUserInfoRequest(BaseModel):
-    """Request to fetch user info using an OAuth token."""
-
-    oauthToken: str
-
-
 class SocrataOAuthUserInfo(BaseModel):
     """Current user info from Socrata after OAuth authentication."""
 
     id: str
     displayName: str
     email: str | None = None
+
+
+# ============================================================================
+# Session Models (covers both OAuth and API Key auth)
+# ============================================================================
+
+
+class SocrataApiKeyRequest(BaseModel):
+    """Request body for saving an API key to the session cookie."""
+
+    apiKeyId: str
+    apiKeySecret: str
+
+
+class SocrataSessionResponse(BaseModel):
+    """State of the current Socrata auth session.
+
+    The `kind` field is null when no session is active. The API key secret is
+    never returned — only the id, for display purposes.
+    """
+
+    kind: Literal["oauth", "api_key"] | None = None
+    user: SocrataOAuthUserInfo | None = None
+    apiKeyId: str | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel
 from typing import Any, Literal
 
+from pydantic import BaseModel
 
 # ============================================================================
 # Chat/Streaming Models

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # ============================================================================
 # Chat/Streaming Models
@@ -149,8 +149,8 @@ class SocrataOAuthUserInfo(BaseModel):
 class SocrataApiKeyRequest(BaseModel):
     """Request body for saving an API key to the session cookie."""
 
-    apiKeyId: str
-    apiKeySecret: str
+    apiKeyId: str = Field(..., max_length=256)
+    apiKeySecret: str = Field(..., max_length=256)
 
 
 class SocrataSessionResponse(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,6 @@ pydantic>=2.5.0
 
 # Environment variable management
 python-dotenv>=1.0.0
+
+# Fernet symmetric encryption for session cookies
+cryptography>=42.0.0

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1570,9 +1570,6 @@ FORMAT RULES:
                 periodOfTime: generatedResults.periodOfTime || undefined,
                 postingFrequency: generatedResults.postingFrequency || undefined,
                 columns: columnUpdates,
-                oauthToken: socrataOAuthToken || undefined,
-                apiKeyId: socrataApiKeyId || undefined,
-                apiKeySecret: socrataApiKeySecret || undefined,
             });
 
             setStatus({ message: result.message, type: 'success' });

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -5,9 +5,11 @@ import { fetchSocrataCategories } from '../utils/categoriesApi';
 import {
     fetchSocrataImport,
     fetchSocrataOAuthLoginUrl,
-    fetchSocrataOAuthUserInfo,
+    fetchSocrataSession,
+    logoutSocrata,
     parseFile,
     pushSocrataMetadata,
+    saveSocrataApiKey,
 } from '../utils/socrataApi';
 import {
     analyzeColumn,
@@ -139,18 +141,14 @@ interface AppContextType {
     socrataDatasetId: string;
     isPushingSocrata: boolean;
 
-    // Socrata OAuth
-    socrataOAuthToken: string | null;
+    // Socrata auth (credentials live in an HttpOnly cookie — never exposed to JS)
     socrataOAuthUser: {id: string; displayName: string; email?: string} | null;
+    socrataApiKeyId: string;  // present only when kind === 'api_key'; never the secret
     isSocrataOAuthAuthenticating: boolean;
     handleSocrataOAuthLogin: () => Promise<void>;
-    handleSocrataOAuthLogout: () => void;
-
-    // Socrata API Key
-    socrataApiKeyId: string;
-    socrataApiKeySecret: string;
-    handleSocrataApiKeySave: (keyId: string, keySecret: string) => void;
-    handleSocrataApiKeyClear: () => void;
+    handleSocrataOAuthLogout: () => Promise<void>;
+    handleSocrataApiKeySave: (keyId: string, keySecret: string) => Promise<void>;
+    handleSocrataApiKeyClear: () => Promise<void>;
 
     // Handlers
     handleAnalyze: (file: File) => Promise<void>;
@@ -305,13 +303,11 @@ export function AppProvider({ children }: {children: ReactNode}) {
     const [socrataDatasetId, setSocrataDatasetId] = useState('');
     const [socrataFieldNameMap, setSocrataFieldNameMap] = useState<Record<string, string>>({});
     const [isPushingSocrata, setIsPushingSocrata] = useState(false);
-    const [socrataOAuthToken, setSocrataOAuthToken] = useState<string | null>(null);
     const [socrataOAuthUser, setSocrataOAuthUser] = useState<{
         id: string; displayName: string; email?: string;
     } | null>(null);
+    const [socrataApiKeyId, setSocrataApiKeyId] = useState<string>('');
     const [isSocrataOAuthAuthenticating, setIsSocrataOAuthAuthenticating] = useState(false);
-    const [socrataApiKeyId, setSocrataApiKeyId] = useState(() => localStorage.getItem('socrata_api_key_id') || '');
-    const [socrataApiKeySecret, setSocrataApiKeySecret] = useState(() => localStorage.getItem('socrata_api_key_secret') || '');
     const [isGeneratingEmpty, setIsGeneratingEmpty] = useState(false);
     const [generatingRowLabel, setGeneratingRowLabel] = useState(false);
     const [generatingDatasetTitle, setGeneratingDatasetTitle] = useState(false);
@@ -402,60 +398,43 @@ export function AppProvider({ children }: {children: ReactNode}) {
         savedDatasetsRef.current.delete(id);
     }, [saveCurrentDataset, restoreDataset]);
 
-    // Socrata OAuth: detect token in URL fragment on mount, or restore from localStorage
+    // Hydrate the Socrata auth session from the backend on mount. Credentials
+    // live in an HttpOnly cookie — the browser never sees the raw token/secret.
     useEffect(() => {
         const hash = window.location.hash;
-        if (hash.startsWith('#oauth_token=')) {
-            const token = hash.slice('#oauth_token='.length);
-            window.history.replaceState(null, '', window.location.pathname);
-
-            setSocrataOAuthToken(token);
-            setIsSocrataOAuthAuthenticating(true);
-
-            fetchSocrataOAuthUserInfo(token)
-                .then((user) => {
-                    setSocrataOAuthUser(user);
-                    localStorage.setItem('socrata_oauth_token', token);
-                    localStorage.setItem('socrata_oauth_user', JSON.stringify(user));
-                    setStatus({ message: `Signed in to data.wa.gov as ${user.displayName}`, type: 'success' });
-                })
-                .catch(() => {
-                    setSocrataOAuthToken(null);
-                    localStorage.removeItem('socrata_oauth_token');
-                    localStorage.removeItem('socrata_oauth_user');
-                    setStatus({ message: 'OAuth sign-in failed: could not verify token', type: 'error' });
-                })
-                .finally(() => setIsSocrataOAuthAuthenticating(false));
-        } else if (hash.startsWith('#oauth_error=')) {
+        if (hash.startsWith('#oauth_error=')) {
             const error = decodeURIComponent(hash.slice('#oauth_error='.length));
             window.history.replaceState(null, '', window.location.pathname);
             setStatus({ message: `OAuth sign-in failed: ${error}`, type: 'error' });
-        } else {
-            // Restore session from localStorage
-            const savedToken = localStorage.getItem('socrata_oauth_token');
-            const savedUser = localStorage.getItem('socrata_oauth_user');
-            if (savedToken && savedUser) {
-                setSocrataOAuthToken(savedToken);
-                setSocrataOAuthUser(JSON.parse(savedUser));
-                setIsSocrataOAuthAuthenticating(true);
-
-                // Verify the saved token is still valid
-                fetchSocrataOAuthUserInfo(savedToken)
-                    .then((user) => {
-                        setSocrataOAuthUser(user);
-                        localStorage.setItem('socrata_oauth_user', JSON.stringify(user));
-                    })
-                    .catch(() => {
-                        // Token expired or invalid — clear session
-                        setSocrataOAuthToken(null);
-                        setSocrataOAuthUser(null);
-                        localStorage.removeItem('socrata_oauth_token');
-                        localStorage.removeItem('socrata_oauth_user');
-                        setStatus({ message: 'Session expired. Please sign in again.', type: 'info' });
-                    })
-                    .finally(() => setIsSocrataOAuthAuthenticating(false));
-            }
+        } else if (hash.startsWith('#oauth_token=')) {
+            // Legacy callback format — strip it from URL. Fresh deploys use cookie-only.
+            window.history.replaceState(null, '', window.location.pathname);
         }
+
+        // Clean up localStorage from previous token-based versions
+        localStorage.removeItem('socrata_oauth_token');
+        localStorage.removeItem('socrata_oauth_user');
+        localStorage.removeItem('socrata_api_key_id');
+        localStorage.removeItem('socrata_api_key_secret');
+
+        setIsSocrataOAuthAuthenticating(true);
+        fetchSocrataSession()
+            .then((session) => {
+                if (session.kind === 'oauth') {
+                    setSocrataOAuthUser(session.user);
+                    setSocrataApiKeyId('');
+                } else if (session.kind === 'api_key') {
+                    setSocrataApiKeyId(session.apiKeyId);
+                    setSocrataOAuthUser(null);
+                } else {
+                    setSocrataOAuthUser(null);
+                    setSocrataApiKeyId('');
+                }
+            })
+            .catch(() => {
+                // No active session — silent, this is the default state
+            })
+            .finally(() => setIsSocrataOAuthAuthenticating(false));
     }, []);
 
     const handleSocrataOAuthLogin = useCallback(async () => {
@@ -470,25 +449,38 @@ export function AppProvider({ children }: {children: ReactNode}) {
         }
     }, []);
 
-    const handleSocrataApiKeySave = useCallback((keyId: string, keySecret: string) => {
-        setSocrataApiKeyId(keyId);
-        setSocrataApiKeySecret(keySecret);
-        localStorage.setItem('socrata_api_key_id', keyId);
-        localStorage.setItem('socrata_api_key_secret', keySecret);
-    }, []);
+    const handleSocrataApiKeySave = useCallback(
+        async (keyId: string, keySecret: string) => {
+            try {
+                await saveSocrataApiKey(keyId, keySecret);
+                setSocrataApiKeyId(keyId);
+                // Saving an API key replaces any OAuth session on the backend.
+                setSocrataOAuthUser(null);
+                setStatus({ message: 'API key saved', type: 'success' });
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : 'Unknown error';
+                setStatus({ message: `Failed to save API key: ${detail}`, type: 'error' });
+            }
+        },
+        [],
+    );
 
-    const handleSocrataApiKeyClear = useCallback(() => {
+    const handleSocrataApiKeyClear = useCallback(async () => {
+        try {
+            await logoutSocrata();
+        } catch {
+            // Ignore — we still clear local state below
+        }
         setSocrataApiKeyId('');
-        setSocrataApiKeySecret('');
-        localStorage.removeItem('socrata_api_key_id');
-        localStorage.removeItem('socrata_api_key_secret');
     }, []);
 
-    const handleSocrataOAuthLogout = useCallback(() => {
-        setSocrataOAuthToken(null);
+    const handleSocrataOAuthLogout = useCallback(async () => {
+        try {
+            await logoutSocrata();
+        } catch {
+            // Ignore — we still clear local state below
+        }
         setSocrataOAuthUser(null);
-        localStorage.removeItem('socrata_oauth_token');
-        localStorage.removeItem('socrata_oauth_user');
         setStatus({ message: 'Signed out from data.wa.gov', type: 'info' });
     }, []);
 
@@ -1302,20 +1294,12 @@ FORMAT RULES:
     }, [csvData, fileName, columnStats, importedRowCount, generateTags]);
 
     const handleSocrataImport = useCallback(
-        async (datasetId: string, keyId?: string, keySecret?: string) => {
+        async (datasetId: string) => {
             setIsProcessing(true);
             setStatus({ message: 'Importing dataset from data.wa.gov...', type: 'info' });
 
-            const effectiveKeyId = keyId !== undefined ? keyId : socrataApiKeyId;
-            const effectiveKeySecret = keySecret !== undefined ? keySecret : socrataApiKeySecret;
-
             try {
-                const result = await fetchSocrataImport(
-                    datasetId,
-                    socrataOAuthToken || undefined,
-                    effectiveKeyId || undefined,
-                    effectiveKeySecret || undefined,
-                );
+                const result = await fetchSocrataImport(datasetId);
 
                 if (!result.sampleRows || result.sampleRows.length === 0) {
                     setStatus({ message: 'No data found in dataset', type: 'error' });
@@ -1394,7 +1378,7 @@ FORMAT RULES:
                 setIsProcessing(false);
             }
         },
-        [socrataOAuthToken, socrataApiKeyId, socrataApiKeySecret, saveCurrentDataset]
+        [saveCurrentDataset]
     );
 
     // Auto-import dataset from ?dataset_id=<id> query parameter on mount
@@ -1455,9 +1439,6 @@ FORMAT RULES:
                 generatedResults.category || undefined,
                 generatedResults.tags.length > 0 ? generatedResults.tags : undefined,
                 columnUpdates,
-                socrataOAuthToken || undefined,
-                socrataApiKeyId || undefined,
-                socrataApiKeySecret || undefined,
             );
 
             setStatus({ message: result.message, type: 'success' });
@@ -1467,7 +1448,7 @@ FORMAT RULES:
         } finally {
             setIsPushingSocrata(false);
         }
-    }, [socrataDatasetId, generatedResults, socrataFieldNameMap, socrataOAuthToken, socrataApiKeyId, socrataApiKeySecret]);
+    }, [socrataDatasetId, generatedResults, socrataFieldNameMap]);
 
     const renderTokenUsage = useCallback(() => {
         if (tokenUsage.totalTokens > 0) {
@@ -1530,13 +1511,11 @@ FORMAT RULES:
         generatingTags,
         socrataDatasetId,
         isPushingSocrata,
-        socrataOAuthToken,
         socrataOAuthUser,
         isSocrataOAuthAuthenticating,
         handleSocrataOAuthLogin,
         handleSocrataOAuthLogout,
         socrataApiKeyId,
-        socrataApiKeySecret,
         handleSocrataApiKeySave,
         handleSocrataApiKeyClear,
         handleAnalyze,

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -49,20 +49,31 @@ export function ImportPage() {
         }
     };
 
-    const handleSocrataSubmit = () => {
+    const handleSocrataSubmit = async () => {
         if (!datasetId.trim()) return;
 
         const trimmedKeyId = apiKeyIdInput.trim();
         const trimmedKeySecret = apiKeySecretInput.trim();
-        const hasCredentials = !!(trimmedKeyId && trimmedKeySecret);
+        const hasNewCredentials = !!(trimmedKeyId && trimmedKeySecret);
 
-        if (rememberKey && hasCredentials) {
-            handleSocrataApiKeySave(trimmedKeyId, trimmedKeySecret);
-        } else if (!rememberKey && (socrataApiKeyId)) {
-            handleSocrataApiKeyClear();
+        // Auth lives in an HttpOnly cookie, so the key must be saved to the
+        // cookie before import can use it. When "Remember" is off we clear
+        // the cookie after the import completes, making it effectively single-use.
+        if (hasNewCredentials) {
+            await handleSocrataApiKeySave(trimmedKeyId, trimmedKeySecret);
+        } else if (!rememberKey && socrataApiKeyId) {
+            await handleSocrataApiKeyClear();
         }
 
-        handleSocrataImport(datasetId.trim(), trimmedKeyId, trimmedKeySecret);
+        try {
+            await handleSocrataImport(datasetId.trim());
+        } finally {
+            if (hasNewCredentials && !rememberKey) {
+                await handleSocrataApiKeyClear();
+                setApiKeyIdInput('');
+                setApiKeySecretInput('');
+            }
+        }
     };
 
     const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -171,7 +182,8 @@ export function ImportPage() {
                         Remember this API key on this browser
                     </label>
                     <span className="import-form-hint">
-                        Generate API keys from your data.wa.gov profile &gt; Developer Settings
+                        Generate API keys from your data.wa.gov profile &gt; Developer Settings.
+                        Saved keys live in an encrypted HttpOnly session cookie.
                     </span>
                 </div>
             )}

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -11,7 +11,6 @@ export function ImportPage() {
         showResults,
         navigate,
         socrataApiKeyId,
-        socrataApiKeySecret,
         handleSocrataApiKeySave,
         handleSocrataApiKeyClear,
     } = useAppContext();
@@ -22,9 +21,9 @@ export function ImportPage() {
     const [datasetId, setDatasetId] = useState('');
     const [showApiKey, setShowApiKey] = useState(!!socrataApiKeyId);
     const [apiKeyIdInput, setApiKeyIdInput] = useState(socrataApiKeyId);
-    const [apiKeySecretInput, setApiKeySecretInput] = useState(socrataApiKeySecret);
+    const [apiKeySecretInput, setApiKeySecretInput] = useState('');
     const [rememberKey, setRememberKey] = useState(true);
-    const apiKeysSaved = !!(socrataApiKeyId && socrataApiKeySecret);
+    const apiKeysSaved = !!socrataApiKeyId;
 
     const csvFileRef = useRef<HTMLInputElement>(null);
     const prevShowResults = useRef(showResults);
@@ -59,7 +58,7 @@ export function ImportPage() {
 
         if (rememberKey && hasCredentials) {
             handleSocrataApiKeySave(trimmedKeyId, trimmedKeySecret);
-        } else if (!rememberKey && (socrataApiKeyId || socrataApiKeySecret)) {
+        } else if (!rememberKey && (socrataApiKeyId)) {
             handleSocrataApiKeyClear();
         }
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,7 +12,6 @@ export function SettingsPage() {
         promptTemplates,
         setPromptTemplates,
         socrataApiKeyId,
-        socrataApiKeySecret,
         handleSocrataApiKeySave,
         handleSocrataApiKeyClear,
     } = useAppContext();
@@ -30,7 +29,7 @@ export function SettingsPage() {
             <div className="settings-page-section">
                 <SocrataApiConfig
                     keyId={socrataApiKeyId}
-                    keySecret={socrataApiKeySecret}
+                    keySecret=""
                     onSave={handleSocrataApiKeySave}
                     onClear={handleSocrataApiKeyClear}
                 />

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,4 @@
-// For Databricks deployment, use empty string (relative URL) when not specified
-// For local development, default to localhost:8000 (Python)
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
+// Default to relative URLs. In dev, Vite's server.proxy forwards /api/* to the
+// backend on :8000 (same origin, so the OAuth session cookie works). In prod,
+// the backend serves the built frontend at the same origin.
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';

--- a/src/utils/socrataApi.ts
+++ b/src/utils/socrataApi.ts
@@ -70,9 +70,6 @@ export interface PushSocrataMetadataOptions {
     periodOfTime?: string;
     postingFrequency?: string;
     columns: {fieldName: string; description: string}[];
-    oauthToken?: string;
-    apiKeyId?: string;
-    apiKeySecret?: string;
 }
 
 export async function pushSocrataMetadata(
@@ -128,9 +125,9 @@ export async function fetchSocrataOAuthLoginUrl(): Promise<string> {
 }
 
 export type SocrataSession =
-    | { kind: 'oauth'; user: { id: string; displayName: string; email?: string } }
-    | { kind: 'api_key'; apiKeyId: string }
-    | { kind: null };
+    | {kind: 'oauth'; user: {id: string; displayName: string; email?: string}}
+    | {kind: 'api_key'; apiKeyId: string}
+    | {kind: null};
 
 export async function fetchSocrataSession(): Promise<SocrataSession> {
     const response = await fetch(`${API_BASE_URL}/api/auth/socrata/session`, {

--- a/src/utils/socrataApi.ts
+++ b/src/utils/socrataApi.ts
@@ -60,18 +60,13 @@ export async function pushSocrataMetadata(
     category: string | undefined,
     tags: string[] | undefined,
     columns: {fieldName: string; description: string}[],
-    oauthToken?: string,
-    apiKeyId?: string,
-    apiKeySecret?: string,
 ): Promise<SocrataExportResult> {
     const response = await fetch(`${API_BASE_URL}/api/socrata/export`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
             datasetId,
-            oauthToken,
-            apiKeyId,
-            apiKeySecret,
             datasetTitle,
             datasetDescription,
             rowLabel,
@@ -86,16 +81,12 @@ export async function pushSocrataMetadata(
     return response.json();
 }
 
-export async function fetchSocrataImport(
-    datasetId: string,
-    oauthToken?: string,
-    apiKeyId?: string,
-    apiKeySecret?: string,
-): Promise<SocrataImportResult> {
+export async function fetchSocrataImport(datasetId: string): Promise<SocrataImportResult> {
     const response = await fetch(`${API_BASE_URL}/api/socrata/import`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ datasetId, oauthToken, apiKeyId, apiKeySecret }),
+        credentials: 'include',
+        body: JSON.stringify({ datasetId }),
     });
 
     await assertResponseOk(response, 'Failed to import dataset');
@@ -123,14 +114,39 @@ export async function fetchSocrataOAuthLoginUrl(): Promise<string> {
     return result.authUrl;
 }
 
-export async function fetchSocrataOAuthUserInfo(
-    oauthToken: string,
-): Promise<{id: string; displayName: string; email?: string}> {
-    const response = await fetch(`${API_BASE_URL}/api/auth/socrata/userinfo`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ oauthToken }),
+export type SocrataSession =
+    | { kind: 'oauth'; user: { id: string; displayName: string; email?: string } }
+    | { kind: 'api_key'; apiKeyId: string }
+    | { kind: null };
+
+export async function fetchSocrataSession(): Promise<SocrataSession> {
+    const response = await fetch(`${API_BASE_URL}/api/auth/socrata/session`, {
+        credentials: 'include',
     });
-    await assertResponseOk(response, 'Failed to fetch user info');
-    return response.json();
+    if (!response.ok) return { kind: null };
+    const data = await response.json();
+    if (data?.kind === 'oauth' && data.user) {
+        return { kind: 'oauth', user: data.user };
+    }
+    if (data?.kind === 'api_key' && data.apiKeyId) {
+        return { kind: 'api_key', apiKeyId: data.apiKeyId };
+    }
+    return { kind: null };
+}
+
+export async function saveSocrataApiKey(apiKeyId: string, apiKeySecret: string): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/api/auth/socrata/api-key`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ apiKeyId, apiKeySecret }),
+    });
+    await assertResponseOk(response, 'Failed to save API key');
+}
+
+export async function logoutSocrata(): Promise<void> {
+    await fetch(`${API_BASE_URL}/api/auth/socrata/logout`, {
+        method: 'POST',
+        credentials: 'include',
+    });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,16 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
     plugins: [react()],
+    server: {
+        // Proxy /api/* to the backend so the OAuth session cookie is same-origin
+        // in dev. Without this, cookies set by :8000 aren't sent by :5173.
+        proxy: {
+            '/api': {
+                target: 'http://localhost:8000',
+                changeOrigin: true,
+            },
+        },
+    },
     build: {
         // For Databricks, output to backend/static
         outDir: mode === 'databricks' ? 'backend/static' : 'dist',


### PR DESCRIPTION
## Summary

- **OAuth cookie session**: OAuth tokens from data.wa.gov are now stored in an encrypted HttpOnly cookie instead of in-memory. HMAC-signed state tokens prevent CSRF attacks on the OAuth callback.
- **API key (Basic Auth) alternative**: Users can authenticate with a Socrata API key instead of OAuth. The key secret is stored in the same encrypted cookie and never touches localStorage. A "Remember this API key" checkbox controls whether the cookie persists or is cleared after a single import.
- **Frontend session discovery**: On load, the frontend calls `/api/auth/socrata/session` to rehydrate auth state from the cookie, so page refreshes don't lose the session.
- **Security**: Secrets are encrypted at rest with Fernet. The API key secret is never exposed to JavaScript. Response headers add HSTS, CSP (`frame-ancestors 'self'`), `X-Frame-Options: SAMEORIGIN`, and `X-Content-Type-Options: nosniff`. CORS is scoped to `FRONTEND_URL` instead of `*`.
- **DEPLOYMENT.md**: Updated to document the API key alternative.

## Test plan

- [ ] Sign in with data.wa.gov via OAuth, verify session persists across page refresh
- [ ] Sign out from OAuth, verify cookie is cleared and subsequent imports require re-auth
- [ ] Enter Socrata API key via Import page with "Remember" **checked** — verify session persists across refresh
- [ ] Enter Socrata API key with "Remember" **unchecked** — verify the import succeeds and the cookie/form clear afterward
- [ ] Save an API key via the Settings page, verify session persists
- [ ] Verify OAuth login errors (expired state, invalid signature, etc.) display correctly in the UI
- [ ] Verify dataset import works with both OAuth and API key auth
- [ ] Verify dataset export (push metadata) returns 401 when no session is active
- [ ] `npm run build:databricks` succeeds